### PR TITLE
Deleted extra spaces and other minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-FTL-Captain-s-Edition-Spellchecking-2015
+FTL-Captain-s-Edition-Spellchecking-2016
 ========================================
 A community effort to spell check the FTL Captain's Edition mod for the roguelike game FTL by Subset Games.
 (2015 Rebirth Edition)
@@ -13,7 +13,7 @@ House rules:
 2. Only spell check things within <text> or <tooltip> capsules. Making changes anywhere else might mess thing up. Never write anything outside of any tags.
 3. Too long texts can cause instability. If you rephrase things, try not to exceed the number of characters the text originally had by too much, especially when the text was already pretty long. A few additional words won't matter if the text was sort too begin with, but somewhere beyond 250 characters the game gets iffy. Also tooltips and weapon description are often deliberately as short as they are, so don't extend them by too much or else they won't fit the UI.
 4. Don't add indent or any kinds of breaks in the text. FTL event texts need to be pure flowtext to work correctly.
-5. Please never make any direct changes in the choices that let the player us the combat augments. That will remove my ability to control these choices globally via find and replace. If you have suggestions how these choice texts could be improved then please post your suggestion as a comment in this repository.
+5. Please never make any direct changes in the choices that let the player use the combat augments. That will remove my ability to control these choices globally via find and replace. If you have suggestions how these choice texts could be improved then please post your suggestion as a comment in this repository.
 6. This repository is for spellchecking, not for sneaking changes you like to see into CE. The mod is free to use for anyone. If you have your own vision how of it should be than you can simply take a copy, make your modifications and release as your own flavour of CE. Here is not the place for this though.
 
 Sections that have not yet been checked by a third party include:

--- a/blueprints.xml.append
+++ b/blueprints.xml.append
@@ -14179,7 +14179,7 @@
 	<title>Pegasus Missile</title>
 	<short>Pegasus</short>
 	<desc>Creative missile design allows for two projectiles for the cost of one!</desc>
-	<tooltip>Fires 2 missiles; 2 damage each; pierces  all shields.</tooltip>
+	<tooltip>Fires 2 missiles; 2 damage each; pierces all shields.</tooltip>
 	<!-- <desc>Power Req: 3    Fires 2 missiles that pierces through all shields and deals 2 damage. Consumes 2 missile per shot.</desc> -->
 	<damage>2</damage>
 	<stun>4</stun>

--- a/events.xml.append
+++ b/events.xml.append
@@ -20205,7 +20205,7 @@
 	<event>
 		<text load="CE_RESEARCH_TEXT"/>
 		<choice req="ghost" hidden="true">
-			<text>Have your AI direct the research team to guaranty success.</text>
+			<text>Have your AI direct the research team to guarantee success.</text>
 			<event load="CE_RESEARCH_LIST_AI"/>
 		</choice>
 		<choice hidden="true">

--- a/events.xml.append
+++ b/events.xml.append
@@ -28983,7 +28983,7 @@
 		</choice>
 	</event>
 	<event>
-		<text>You tell yourself that the mission is more important than these civilians. The live of millions depend on you. Your crew doesn't seem to see it exactly like that, but they follow their orders.</text>
+		<text>You tell yourself that the mission is more important than these civilians. The lives of millions depend on you. Your crew doesn't seem to see it exactly like that, but they follow their orders.</text>
 		<ship hostile="true"/>
 		<choice hidden="true">
 			<text>Continue...</text>

--- a/events.xml.append
+++ b/events.xml.append
@@ -17879,7 +17879,7 @@
 		</choice>
 	</event>
 	<event>
-		<text>It turns out that your opponent is quite terrified by Zoltan authority. In addition to transferring the agreed amount of supplies, they also insist on immediately repairing some of the the damage done to your ship.</text>
+		<text>It turns out that your opponent is quite terrified by Zoltan authority. In addition to transferring the agreed amount of supplies, they also insist on immediately repairing some of the damage done to your ship.</text>
 		<ship hostile="false"/>
 		<autoReward level="MED">standard</autoReward>
 		<damage amount="-5"/>
@@ -24957,7 +24957,7 @@
 	<text>The Rockman says it despises the corrupt religious ruling class of its society, but it still turns to pray to the Gods in time of need.</text>
 	<text>The Rockman explains that the Rock religion is not inherently bad, the problem are the many extremists and corrupt individuals among the leading Rock basilisks.</text>
 	<text>The Rockman talks about its past. The being was working in a missile manufacturing plant with thousands of other workers. After many standard decades, it left and joined the Federation due to an unusual thirst for adventure.</text>
-	<text>The Rockman is busy carrying several containers of FTL fuel to the the engine room.</text>
+	<text>The Rockman is busy carrying several containers of FTL fuel to the engine room.</text>
 	<text>The Rockman is seriously wondering how it feels to be burned. You try to explain the sensation, but seem unable to convey the idea. "What do you mean by 'ardent', Captain?"</text>
 	<text>The Rockman explains that many of their former friends only treat them as a heretic for joining the Federation.</text>
 	<text>The Rockman admits it is, sometimes, longing for the dusty air of its home world. The being usually smashes something to get rid of the feeling.</text>
@@ -24993,7 +24993,7 @@
 	<text>Your Rockman is worried by all the hostility in this sector. "Battle is honorable, but endless battle brings only destruction." The conversation drifts off and the Rock crew member shares some memories of the Rock Grand Inquisition on the home worlds. A dark and ongoing chapter in its species history.</text>
 	<text>Your Rockman wonders if the ship will make it through this dangerous sector. "I'm not questioning your combat efficiency, but there is only so many hits a vessel can take. And we face many enemies..."</text>
 	<text>Your Rockman never thought it would face such great opponents as in this sector. "I fought the Rock Inquisition as a pirate for some years. Did you know that Captain?" The crew member claims the Inquisition would, had he ever been caught, thrown him alive into a sun. In order to "purify" the being.</text>
-	<text>All the combat in this sector reminds your Rockman of the the great battles its kind has fought.</text>
+	<text>All the combat in this sector reminds your Rockman of the great battles its kind has fought.</text>
 </textList>
 
 <eventList name="CE_CONVERSATION_ZOLTAN_GENERIC">
@@ -27919,7 +27919,7 @@
 	<text>The beacon is flagged as "liberated", but suprisingly there are no ships around. The fleet must have moved on already. You can't believe your luck.</text>
 	<text>You spot a few cruisers in the distance, but they move away quickly and do not seem to notice you. It is clear that you won't be always this lucky. You have to get out of Rebel territory immediately.</text>
 	<text>This beacon is under Rebel control, but the fleet has not reinforced this position and did not even leave a guard unit. A mistake you can now exploit.</text>
-	<text>The Rebels have already move past the beacon and suddenly you find yourself behind enemy lines. You try to lay low and it is only luck that there are so few ships in the the vicinity. A few auto scouts zip past, but do not actively scan and just seem to be dedicated to reach the front line as fast as possible.</text>
+	<text>The Rebels have already move past the beacon and suddenly you find yourself behind enemy lines. You try to lay low and it is only luck that there are so few ships in the vicinity. A few auto scouts zip past, but do not actively scan and just seem to be dedicated to reach the front line as fast as possible.</text>
 	<text>To your surprise, no hostile ships are in the area. The front line must have moved already. Large caravans of civilian ships slowly follow in the wake of the fleet. Are these sympathizers? Traders? The rebels families? You have to lay low, so you can't find out.</text>
 	<text>The Rebel guard units have been stationed far in the distance to deter any threads to a large civilian caravan. The people here naturally assume that you are a deserter or Rebel mercenary and engage in friendly chatting. They hope to found a new colony somewhere in conquered Rebel space, since their home planet has been devastated in the current conflict.</text>
 </textList>
@@ -32066,7 +32066,7 @@
 			<choice hidden="true">
 				<text>Continue...</text>
 				<event>
-					<text>Internal scans indicate that they teleported some advanced equipment. They are also deploying combat avatars to strengthen their numbers. You order your crew to fend of the the boarders and prepare to seize their gear.</text>
+					<text>Internal scans indicate that they teleported some advanced equipment. They are also deploying combat avatars to strengthen their numbers. You order your crew to fend off the boarders and prepare to seize their gear.</text>
 					<boarders min="1" max="3" class="ghost"/>
 					<autoReward level="LOW">standard</autoReward>
 				</event>

--- a/events_boss.xml.append
+++ b/events_boss.xml.append
@@ -3539,7 +3539,7 @@
 </textList>
 <eventList name="C_REBEL_CRUISER_BOSS_RESCUE_LIST">  <!-- what the player gets for rescuing the ship-->
 	<event>
-		<text>You are hailed, "Thank you!  We will send out some repair drones to fix as much damage to your ship as possible. Good luck with your mission!"</text>
+		<text>You are hailed, "Thank you! We will send out some repair drones to fix as much damage to your ship as possible. Good luck with your mission!"</text>
 		<damage amount="-15"/>
 	</event>
 	<event>
@@ -3547,7 +3547,7 @@
 		<autoReward level="HIGH">stuff</autoReward>
 	</event>
 	<event>  <!-- Gives new repair station-->
-		<text>You receive a message on encrypted Federation channels.  It says, "Thanks for helping us, Captain. Our drones can fix some of the damage that was done to your ship. We were in the process of setting up another repair station nearby. We can give you the coordinates."</text>
+		<text>You receive a message on encrypted Federation channels. It says, "Thanks for helping us, Captain. Our drones can fix some of the damage that was done to your ship. We were in the process of setting up another repair station nearby. We can give you the coordinates."</text>
 		<damage amount="-5"/>
 		<quest event="BOSS_REPAIR_STATION"/>
 	</event>
@@ -5094,7 +5094,7 @@ IDEAS
 		<autoReward level="MED">stuff</autoReward>
 	</event>
 	<event>  
-		<text>You receive a message on encrypted Federation channels.  It says, "Thanks for helping us, Captain. Our drones can fix some of the damage that was done to your ship."</text>
+		<text>You receive a message on encrypted Federation channels. It says, "Thanks for helping us, Captain. Our drones can fix some of the damage that was done to your ship."</text>
 		<damage amount="-5"/>
 	</event>
 </eventList>

--- a/events_crystal.xml.append
+++ b/events_crystal.xml.append
@@ -1154,7 +1154,7 @@
 
 
 <event name="CRYSTAL_FED_DESERTER" unique="true">
-	<text>For a moment you assume it's a glitch,  but no... you've found a Federation military ship! They hail you and, after some probing, reveal that they deserted the Federation fleet before stumbling into this sector while seeking refuge.</text>
+	<text>For a moment you assume it's a glitch, but no... you've found a Federation military ship! They hail you and, after some probing, reveal that they deserted the Federation fleet before stumbling into this sector while seeking refuge.</text>
 	<ship load="FED_SHIP" hostile="false"/>
 	<choice hidden="true">
 		<text>Offer supplies.</text>
@@ -1736,12 +1736,12 @@
 	<store/>
 </event>
 <textList name="STORE_CRYSTAL">
-	<text>You arrive in an area bustling with crystalline ships and stations.  A merchant quickly messages you, "You're from the outside, no? This is a great opportunity for both of us! Do you have anything you wish to sell or trade?"</text>
+	<text>You arrive in an area bustling with crystalline ships and stations. A merchant quickly messages you, "You're from the outside, no? This is a great opportunity for both of us! Do you have anything you wish to sell or trade?"</text>
 	<text>"Ah! Hello, aliens", says a rotund crystalline being on the vidscreen. "I hoped I would run into one of you. I am a collector of alien artifacts and hoped you would have some equipment to barter!"</text>
 	<text>You arrive at a trade depot and find a store that is willing to open communications with you. "I can't say I've traded with your kind before, but perhaps we could work out some sort of exchange."</text>
 	<text>You receive an incoming transmission, but it seems badly garbled. Eventually you realize it's advertising an equipment store. "Apologies," says the vendor, when you finally get him on the vidscreen, "Long time since use universal translator necessary. Please, buy, buy!"</text>
 	
-	<text>You arrive in an area bustling with crystalline ships and stations.  A merchant quickly messages you, "You're from the outside, no? This is a great opportunity for both of us! Do you have anything you wish to sell or trade?"</text>
+	<text>You arrive in an area bustling with crystalline ships and stations. A merchant quickly messages you, "You're from the outside, no? This is a great opportunity for both of us! Do you have anything you wish to sell or trade?"</text>
 	<text>"Ah! Hello, aliens", says a rotund crystalline being on the vidscreen. "I hoped I would run into one of you. I am a collector of alien artifacts and hoped you would have some equipment to barter!"</text>
 	<text>You arrive at a trade depot and find a store that is willing to open communications with you. "I can't say I've traded with your kind before, but perhaps we could work out so sort of exchange?"</text>
 	<text>You receive an incoming transmission, but it seems badly garbled. Eventually you realize it's advertising an equipment store. "Apologies," says the vendor, when you finally get him on the vidscreen, "Long time since use universal translator necessary. Please, buy, buy!"</text>

--- a/events_engi.xml.append
+++ b/events_engi.xml.append
@@ -202,12 +202,12 @@
 <textList name="NOTHING_ENGI_TEXT">
 	<text>The complex arrangements of ship hulls and FTL drive capacitors floating abandoned in space suggest the Engi were here not too long ago, but no longer.</text>
 	<text>You arrive at a green planet with great plains and rolling waterfalls. It would be of little interest to the Engi nearby.</text>  <!-- JUSTIN TO DO-  MAKE GREEN PLANET-->
-	<text>You have arrived near an Engi construction yard.  Most Engi maintain their bipedal appearance out of habit but here you see a number of Engi hives working together to create massive organic machines adept at building ships.  Truly a sight to behold.</text>
-	<text>Even though each "individual" Engi is made up of trillions of nanomachines, their culture still revolves around traditional social interactions.  A nearby station seems to be constructed for entertainment of passing Engi travelers.</text>
-	<text>You see a number of Engi space stations and fleets nearby.  Despite looking like piles of junk loosely tied together they are actually a model of efficiency.  They just lack a certain aesthetic emphasis in their construction.</text>
-	<text>This system appears quite peaceful.  You're not sure how long it'll last between the combined threats of the Rebels and Mantis.</text>
-	<text>There are a number of merchant ships passing through the area despite the threat of a Mantis invasion.  No doubt interested in buying the efficient technology of the Engi.</text>
-	<text>You see a small Rebel carrier in the distance.  You lay low and try to blend in with the other traffic.  However it's surprising to see a Rebel military ship alone deep in Engi space.</text>
+	<text>You have arrived near an Engi construction yard. Most Engi maintain their bipedal appearance out of habit but here you see a number of Engi hives working together to create massive organic machines adept at building ships. Truly a sight to behold.</text>
+	<text>Even though each "individual" Engi is made up of trillions of nanomachines, their culture still revolves around traditional social interactions. A nearby station seems to be constructed for entertainment of passing Engi travelers.</text>
+	<text>You see a number of Engi space stations and fleets nearby. Despite looking like piles of junk loosely tied together they are actually a model of efficiency. They just lack a certain aesthetic emphasis in their construction.</text>
+	<text>This system appears quite peaceful. You're not sure how long it'll last between the combined threats of the Rebels and Mantis.</text>
+	<text>There are a number of merchant ships passing through the area despite the threat of a Mantis invasion. No doubt interested in buying the efficient technology of the Engi.</text>
+	<text>You see a small Rebel carrier in the distance. You lay low and try to blend in with the other traffic. However it's surprising to see a Rebel military ship alone deep in Engi space.</text>
 	<text>The Engi seem to have avoided this particular node, along with every other life-form. You keep your eyes peeled for reasons why, but spin up the FTL without event.</text>
 	<text>A cluster of Engi satellites in orbit of a nearby planet are the only clue the mechanical species was ever here. You have other places to be.</text>
 </textList>
@@ -733,7 +733,7 @@
 
 <eventList name="ENGI_STATION_DISTRESS_LIST">
 	<event>
-		<text>You receive another message from the ship, this time with a Mantis at the comm.  "Foolish meatsacks," he yells.  Sensors indicate the ship is moving in to attack.</text>
+		<text>You receive another message from the ship, this time with a Mantis at the comm. "Foolish meatsacks," he yells. Sensors indicate the ship is moving in to attack.</text>
 		<choice req="AE_TELEPORTER_JAMMER" hidden="true">
 			<text>(Teleporter Disruptor) The Mantis surely will try to board. Get our defenses online!</text>
 			<event>
@@ -843,7 +843,7 @@
 		</choice>
 	</event>
 	<event>
-		<text>You approach to find a Mantis ship assaulting a small Engi space station.  You prepare for a fight!</text>
+		<text>You approach to find a Mantis ship assaulting a small Engi space station. You prepare for a fight!</text>
 		<ship load="MANTIS_ENGI_STATION" hostile="true"/>
 		<choice hidden="true">
 			<text>Continue...</text>
@@ -1017,7 +1017,7 @@
 </event>
 
 <event name="ENGI_UNLOCK_2FAKE">
-	<text>You arrive at one of the Rebel bases that the Engi told you about.  It appears abandoned except for one scout ship.  Perhaps you could extract information from them.</text>
+	<text>You arrive at one of the Rebel bases that the Engi told you about. It appears abandoned except for one scout ship. Perhaps you could extract information from them.</text>
 	<ship load="REBEL_ENGI_UNLOCK_2FAKE" hostile="true"/>
 		<choice hidden="true">
 			<text>Continue...</text>
@@ -1066,7 +1066,7 @@
 </event>
 
 <event name="ENGI_UNLOCK_2REAL">
-	<text>You arrive at one of the Rebel bases that the Engi told you about.  It appears abandoned except for one scout ship.  Perhaps you could extract information from them."</text>
+	<text>You arrive at one of the Rebel bases that the Engi told you about. It appears abandoned except for one scout ship. Perhaps you could extract information from them."</text>
 	<ship load="REBEL_ENGI_UNLOCK_2REAL" hostile="true"/>
 		<choice hidden="true">
 			<text>Continue...</text>
@@ -1115,7 +1115,7 @@
 </event>
 
 <event name="ENGI_UNLOCK_3">
-	<text>You have finally caught up with the ships you've been hunting.  A hangar-sized cargo ship is being escorted by a number of Mantis ships.  As you reconsider the assault, a squadron of Engi ships with pirate emblems jump in and assist you.  You prepare to fight the Mantis but scans indicate they are manned by Rebels!</text>
+	<text>You have finally caught up with the ships you've been hunting. A hangar-sized cargo ship is being escorted by a number of Mantis ships. As you reconsider the assault, a squadron of Engi ships with pirate emblems jump in and assist you. You prepare to fight the Mantis but scans indicate they are manned by Rebels!</text>
 	<ship load="MANTIS_ENGI_UNLOCK_3" hostile="true"/>
 		<choice hidden="true">
 			<text>Continue...</text>
@@ -1999,21 +1999,21 @@
 		<choice hidden="true">
 			<text>Request fuel.</text>
 			<event>
-				<text>"Request granted.  Fuel transferring."</text>
+				<text>"Request granted. Fuel transferring."</text>
 				<autoReward level="HIGH">fuel</autoReward>
 			</event>
 		</choice>
 		<choice hidden="true">
 			<text>Request weapon.</text>
 			<event>
-				<text>"Request granted.  Weapon transferring."</text>
+				<text>"Request granted. Weapon transferring."</text>
 				<autoReward level="LOW">weapon</autoReward>
 			</event>
 		</choice>
 		<choice hidden="true">
 			<text>Request drone.</text>
 			<event>
-				<text>"Request granted.  Drone schematic transferring."</text>
+				<text>"Request granted. Drone schematic transferring."</text>
 				<autoReward level="LOW">drone</autoReward>
 			</event>
 		</choice>
@@ -4890,7 +4890,7 @@
 </event>
 <textList name="NOTHING_QUARANTINE_TEXT">
 	<text>As the blueish shimmer of FTL-charged particles fades away, you find yourself in a dead-silent part of the sector. However, you pick up several hundred objects floating in the space around the beacon, barely radiating any heat. They appear to be bodies - you have arrived at a graveyard for the victims of the plague.</text>
-	<text>Despite the local health crisis, this system appears quite peaceful.  You're not sure how long it'll last between the combined threats of the Rebels, Mantis and the disease.</text>
+	<text>Despite the local health crisis, this system appears quite peaceful. You're not sure how long it'll last between the combined threats of the Rebels, Mantis and the disease.</text>
 	<text planet="PLANET_POPULATED_SMALL">The nearby planet shows sign of habitation and great beauty. A rudimentary automated planetary defense system is looping its message into space, "Warning! Quarantine Level 5 in effect under FHA Act 22, article 11.2. Warning! Quarantine Level 5 ..."</text>
 	<text planet="PLANET_POPULATED_SMALL">All local news channels report exclusively on the current health crisis. Some journalists claim the disease is actually a virus-based bioweapon and was developed in the labs of a huge arms manufacturer.</text>
 	<text planet="PLANET_POPULATED_SMALL">The news network of this small planet broadcasts to the entire system. A virtual anchor man summarizes the current findings, which indicate that the plague is actually a nano virus, released by a deranged AI in a far away sector.</text>
@@ -5746,7 +5746,7 @@
 		</choice>
 	</event>
 	<event>
-		<text>All hell breaks loose when the bay doors open. A team of humans runs for the ship. "We are Federation medical officers and advise you to get this ship out of here immediately; they are coming! Everyone but us is infected here!"  The crew fails to hold off the infected until the ship detaches. Some of the crazed beings enter the ship and several of your original crewmen are bitten.</text>
+		<text>All hell breaks loose when the bay doors open. A team of humans runs for the ship. "We are Federation medical officers and advise you to get this ship out of here immediately; they are coming! Everyone but us is infected here!" The crew fails to hold off the infected until the ship detaches. Some of the crazed beings enter the ship and several of your original crewmen are bitten.</text>
 		<boarders min="2" max="3" class="random"/>
 		<crewMember amount="-2" class="traitor"/>
 		<choice hidden="true">
@@ -6306,7 +6306,7 @@
 	<text>"Alright, you win! Here's some equipment from our stores, leave us alone!"</text>
 	<text>The ship repeatedly hails you. It looks like they want to surrender.</text>
 	<text>"You are considerably more well-armed than I would have thought. We surrender."</text>
-	<text>You get a frantic message, "Take everything we have!  Just don't kill us."</text>
+	<text>You get a frantic message, "Take everything we have! Just don't kill us."</text>
 	<text>"You have clearly bested us. We merely request our lives."</text>
 	<text>"Please cease fire, enough people are dying around these parts."</text>
 </textList>

--- a/events_fuel.xml.append
+++ b/events_fuel.xml.append
@@ -1832,14 +1832,14 @@
 	
 <eventList name="FUEL_APPROACH_ACCEPT_LIST">
 	<event>
-		<text>They pull close to your ship and unload some fuel saying, "Try not to run out of fuel again.  These are dangerous times; who knows who could have showed up."</text>
+		<text>They pull close to your ship and unload some fuel saying, "Try not to run out of fuel again. These are dangerous times; who knows who could have showed up."</text>
 		<ship load="CIVILIAN_SHIP" hostile="false"/>
 		<item_modify>
 			<item type="fuel" min="2" max="6"/>
 		</item_modify>
 	</event>
 	<event>   <!-- this continues in the DISTRESS section -->
-		<text>They approach and dock with your ship.  On board they present an offer.</text>
+		<text>They approach and dock with your ship. On board they present an offer.</text>
 		<ship load="CIVILIAN_SHIP" hostile="false"/>
 		<choice>
 			<text>Gladly trade.</text>
@@ -1851,7 +1851,7 @@
 		</choice>
 	</event>
 	<event>
-		<text>As their ship pulls up next to yours, their Captain continues, "Yes, we'll certainly help...  Help to relieve you of that nice ship!"  Sensors detect a hidden teleporter has been activated.</text>
+		<text>As their ship pulls up next to yours, their Captain continues, "Yes, we'll certainly help... Help to relieve you of that nice ship!" Sensors detect a hidden teleporter has been activated.</text>
 		<ship load="PIRATE_FUEL" hostile="false"/>
 		<choice req="AE_TELEPORTER_JAMMER" hidden="true">
 			<text>(Teleporter Disruptor) Deflect their teleporter signal.</text>
@@ -1958,7 +1958,7 @@
 		</choice>
 	</event>
 	<event>
-		<text>As they approach, you detect their weapons powering up.  It seems their intentions are hostile!</text>
+		<text>As they approach, you detect their weapons powering up. It seems their intentions are hostile!</text>
 		<ship load="PIRATE" hostile="true"/>
 		<choice hidden="true">
 			<text>Continue...</text>
@@ -2012,17 +2012,17 @@
 </eventList>
 <eventList name="FUEL_APPROACH_DECLINE_LIST">
 	<event>
-		<text>"I assure you that we mean no harm.  See, we'll send some fuel over on a transport."  A small ship docks and offloads some fuel just as they said.  They leave, saying, "Stay cautious, friend."</text>
+		<text>"I assure you that we mean no harm. See, we'll send some fuel over on a transport." A small ship docks and offloads some fuel just as they said. They leave, saying, "Stay cautious, friend."</text>
 		<ship load="CIVILIAN_SHIP" hostile="false"/>
 		<item_modify>
 			<item type="fuel" min="1" max="4"/>
 		</item_modify>
 	</event>
 	<event>
-		<text>"No one trusts anyone these days..."  The ship jumps away.</text>
+		<text>"No one trusts anyone these days..." The ship jumps away.</text>
 	</event>
 	<event>
-		<text>They reply,"Keep our distance?  Let's see if you can stop us!"  They power up their weapons and advance.</text>
+		<text>They reply,"Keep our distance? Let's see if you can stop us!" They power up their weapons and advance.</text>
 		<ship load="PIRATE_FUEL" hostile="true"/>
 		<choice hidden="true">
 			<text>Continue...</text>
@@ -2076,13 +2076,13 @@
 </eventList>
 <eventList name="FUEL_APPROACH_SCAN_LIST">
 	<event>
-		<text>Sensors indicate their ship is without military-grade weaponry, even small arms.  You allow them to dock and they give you some fuel saying, "I remember a time when we didn't have to be so paranoid about each others intentions... Stay safe."</text>
+		<text>Sensors indicate their ship is without military-grade weaponry, even small arms. You allow them to dock and they give you some fuel saying, "I remember a time when we didn't have to be so paranoid about each others intentions... Stay safe."</text>
 		<item_modify>
 			<item type="fuel" min="3" max="7"/>
 		</item_modify>
 	</event>
 	<event>
-		<text>Sensors are picking up armed crew and considerably more weaponry than is legal for a craft of this size.  This is surely a trap.</text>
+		<text>Sensors are picking up armed crew and considerably more weaponry than is legal for a craft of this size. This is surely a trap.</text>
 		<choice>
 			<text>Prepare for a fight.</text>
 			<event>
@@ -2141,7 +2141,7 @@
 		<choice req="cloaking" hidden="true"> 
 			<text>(Cloaking) Cloak and get out of scanning range before they have a chance to lock on.</text>
 			<event>
-				<text>Your highly advanced cloaking system allows you to get out of range easily since they were still out of firing range.  Eventually the ship jumps away.</text>
+				<text>Your highly advanced cloaking system allows you to get out of range easily since they were still out of firing range. Eventually the ship jumps away.</text>
 			</event>
 		</choice>
 	</event>		

--- a/events_mantis.xml.append
+++ b/events_mantis.xml.append
@@ -479,7 +479,7 @@
 	</choice>
 </event>
 <textList name="START_BEACON_MANTIS_TEXT">
-	<text>You've entered a poorly charted area of space that's known to be home to the Mantis.  Ensure your hull plating is up to scratch and that you have enough fuel in the tank to make it through.</text>
+	<text>You've entered a poorly charted area of space that's known to be home to the Mantis. Ensure your hull plating is up to scratch and that you have enough fuel in the tank to make it through.</text>
 	<text>You've arrived in a sector controlled by the Mantis. Their expansion to this sector has already cost many lives. You should be careful here.</text>
 	<text>You've entered a recently established Mantis hive cluster. Some civilian settlements remain, but most of the sentient individuals that lived here have been murdered or made their way out of the sector.</text>
 	<text>You've entered one of the many Mantis hive clusters. Traveling through these areas of space is no joke. You should be vigilant.</text>

--- a/events_nebula.xml.append
+++ b/events_nebula.xml.append
@@ -440,7 +440,7 @@
 	</choice>
 </event>
 <textList name="START_BEACON_NEBULA">
-	<text>This nebula must have been an important hub at one point; placing all of these jump beacons would be no easy task.  However, now it's hardly navigable.</text>
+	<text>This nebula must have been an important hub at one point; placing all of these jump beacons would be no easy task. However, now it's hardly navigable.</text>
 	<text>Nebulae were always dangerous places. Many electronics fail in these clouds. You will have to tread lightly.</text>
 	<text>You've entered a sector thick with nebulae. You'll have to navigate on instinct.</text>
 	<text>You've entered a nebula-rich sector. You may put a few light years on the fleet, but that's only useful if you make it out the other side.</text>
@@ -2314,7 +2314,7 @@
 </event>
 <textList name="NEBULA_BOARDING_TEXT">
 	<text>You see a small pirate station nearby. You can't be sure without sensors, but they might be preparing to board you.</text> 
-	<text>You arrive in the nebula and immediately receive a distorted message, "Prepare to be boarded!"  With the static from the nebula, there's no way to tell where they broadcast from.</text>
+	<text>You arrive in the nebula and immediately receive a distorted message, "Prepare to be boarded!" With the static from the nebula, there's no way to tell where they broadcast from.</text>
 	<text>You see a number of derelict ships near this beacon. After a short time the ship computer puts a teleporter warning on the vidscreen.</text>
 </textList>
 
@@ -3045,7 +3045,7 @@
 </event>
 <textList name="BS_EVENT_PIRATE_NEBULA_TEXT">
 		<text>As you drift through the nebula, the outlines of an unlicensed station become visible within the clouds. Its weapons come live.</text>
-	<text>A pirate station drifts near the beacon and hails, "Look who we have here. In the end they always come to us. Our cargo scans indicate fine prizes aboard your ship, you won't leave here in one piece."  They lock weapons.</text>
+	<text>A pirate station drifts near the beacon and hails, "Look who we have here. In the end they always come to us. Our cargo scans indicate fine prizes aboard your ship, you won't leave here in one piece." They lock weapons.</text>
 	<text>Your attempts to ID the station ahead are fruitless. When you close in a little you realize that it is a fully armed pirate station that gets its weapons ready!</text>	
 </textList>
 
@@ -8545,7 +8545,7 @@ IDEAS
 
 <event name="BOARDERS_ASTEROID_AI_GHOST" unique="true">
 	<img back="BG_DARK" planet="NONE"/>
-	<text>You jump into the middle of an asteroid field.  Looking around, you find you are surrounded by dozens of wrecks of other ships.  Faint wisps of light can be seen moving between wrecks.  As you watch, they seem to be changing path and floating toward your ship!</text>
+	<text>You jump into the middle of an asteroid field. Looking around, you find you are surrounded by dozens of wrecks of other ships. Faint wisps of light can be seen moving between wrecks. As you watch, they seem to be changing path and floating toward your ship!</text>
 	<choice>
 		<text>Scan the entities.</text>
 			<event>
@@ -8588,7 +8588,7 @@ IDEAS
 	<choice req="pilot" lvl="2" hidden="true"> 
 		<text>(Piloting) Have your pilot maneuver you out of the asteroid field.</text>
 		<event>
-			<text>Thanks to your pilot, you were able escape the worst of the asteroid field unscathed.  However, the wisps of light stream out of the field following your ship!</text>
+			<text>Thanks to your pilot, you were able escape the worst of the asteroid field unscathed. However, the wisps of light stream out of the field following your ship!</text>
 			<choice hidden="true">
 				<text>Scan the entities.</text>
 				<event>
@@ -8657,7 +8657,7 @@ IDEAS
 		<choice req="sensors" lvl="2" hidden="true"> 
 			<text>(Sensors) Wait, sensors are picking up something strange...</text>
 			<event>
-				<text>Your sensors are picking up some subtle but anomalous activity, it's as if the ship is slowly activating.  You pull everyone back to your ship with what they have gathered.</text>
+				<text>Your sensors are picking up some subtle but anomalous activity, it's as if the ship is slowly activating. You pull everyone back to your ship with what they have gathered.</text>
 				<autoReward level="MED">scrap_only</autoReward>
 				<choice hidden="true"> 
 					<text>Continue</text>

--- a/events_pirate.xml.append
+++ b/events_pirate.xml.append
@@ -3321,7 +3321,7 @@
 		<augment name="TE_GOODS_TEXTILES"/>
 	</event>
 	<event>
-		<text>Once you bring the cargo onto your ship a pirate bursts out of one of the crates saying, "Ugh... I was getting cramped in there.  Oh, yeah! Prepare to die!" Immediately after this battle-cry your ship is filled with the sound of crates breaking open...</text>
+		<text>Once you bring the cargo onto your ship a pirate bursts out of one of the crates saying, "Ugh... I was getting cramped in there. Oh, yeah! Prepare to die!" Immediately after this battle-cry your ship is filled with the sound of crates breaking open...</text>
 		<boarders min="2" max="4" class="random"/>
 	</event>
 	<event>
@@ -3374,7 +3374,7 @@
 		</choice>
 	</event>
 	<event>
-		<text>Once you bring the cargo onto your ship a pirate bursts out of one of the crates saying, "Ugh... I was getting cramped in there.  Oh, yeah! Prepare to die!" Immediately after this battle-cry your ship is filled with the sound of crates breaking open...</text>
+		<text>Once you bring the cargo onto your ship a pirate bursts out of one of the crates saying, "Ugh... I was getting cramped in there. Oh, yeah! Prepare to die!" Immediately after this battle-cry your ship is filled with the sound of crates breaking open...</text>
 		<boarders min="2" max="4" class="random"/>
 	</event>
 	<event>
@@ -3448,7 +3448,7 @@
 		<autoReward level="MED">standard</autoReward>
 	</event>
 	<event>
-		<text>Your advanced sensors pick up faint life signatures inside the cargo. The life forms appear to be armed.  This looks like a planned pirate ambush.</text>
+		<text>Your advanced sensors pick up faint life signatures inside the cargo. The life forms appear to be armed. This looks like a planned pirate ambush.</text>
 		<choice hidden="true">
 			<text>Destroy the crates to prevent another ship from falling victim.</text>
 			<event>
@@ -3506,7 +3506,7 @@
 		</choice>
 	</event>
 	<event>
-		<text>Your advanced sensors pick up faint life signatures inside the cargo. The life forms appear to be armed.  This looks like a planned pirate ambush.</text>
+		<text>Your advanced sensors pick up faint life signatures inside the cargo. The life forms appear to be armed. This looks like a planned pirate ambush.</text>
 		<choice hidden="true">
 			<text>Destroy the crates to prevent another ship from falling victim.</text>
 			<event>
@@ -3564,7 +3564,7 @@
 		</choice>
 	</event>
 	<event>
-		<text>Your advanced sensors pick up faint life signatures inside the cargo. The life forms appear to be armed.  This looks like a planned pirate ambush.</text>
+		<text>Your advanced sensors pick up faint life signatures inside the cargo. The life forms appear to be armed. This looks like a planned pirate ambush.</text>
 		<choice hidden="true">
 			<text>Destroy the crates to prevent another ship from falling victim.</text>
 			<event>
@@ -3622,7 +3622,7 @@
 		</choice>
 	</event>
 	<event>
-		<text>Your advanced sensors pick up faint life signatures inside the cargo. The life forms appear to be armed.  This looks like a planned pirate ambush.</text>
+		<text>Your advanced sensors pick up faint life signatures inside the cargo. The life forms appear to be armed. This looks like a planned pirate ambush.</text>
 		<choice hidden="true">
 			<text>Destroy the crates to prevent another ship from falling victim.</text>
 			<event>
@@ -3808,7 +3808,7 @@
 		</choice>
 </event>
 <textList name="BS_EVENT_PIRATE_TEXT">
-	<text>As you jump into the system  you find yourself right in front of a small pirate station. They are refusing all hails. Prepare for a fight.</text>
+	<text>As you jump into the system you find yourself right in front of a small pirate station. They are refusing all hails. Prepare for a fight.</text>
 	<text>Immediately after arriving in the system you are hailed by a station, "We know who you are and what you carry. You will have to get past us if you want to jump from this beacon. Except you won't."</text>
 	<text>This beacon lies in close proximity to a considerably well armed pirate station. You will have to stay in their weapon range if you want to charge your FTL drive... According to the confused, apparently drug influenced comm chatter you receive the pirates seem quite amused by that.</text>
 	<text>A station at this beacon messages you, "Greetings, assholes. We are almost out of food and fuel here. We might have more if we would trade instead of destroying every ship that comes here, but that wouldn't be so exciting, right?"</text>

--- a/events_rebel.xml.append
+++ b/events_rebel.xml.append
@@ -233,11 +233,11 @@
 	</choice>
 </event>
 <textList name="NOTHING_REBEL">
-	<text>You enter a system bustling with Rebel activity.  Supply freighters and re-supply stations are dwarfed by a few heavy warships.  Luckily, no one seems to be paying attention to small cruisers.  No ships are scanning or messaging you.</text>
-	<text>You arrive near a small Rebel refueling depot.  Your ship is being scanned multiple times so they must recognize you, but there appears to be no combat-ready ships in the vicinity.  The only message you receive is a denial to your request to dock at the depot.</text> 
-	<text>There is not much of interest nearby.   A small sun in the distance with a few orbiting planets in nearby space provide little of interest.</text>
-	<text planet="NONE">There are no other ships near this beacon, however you detect a small communications relay.  You tap into it without a problem; there are no encryptions.  Most of the chatter revolves around troop and fleet movements, nothing particularly interesting.</text>
-	<text planet="PLANET_POPULATED_SMALL">There is a small planet nearby with scattered settlements.  A small Rebel fleet is in orbit with many ships ferrying back and forth.  It must be a recently 'liberated' planet.</text>
+	<text>You enter a system bustling with Rebel activity. Supply freighters and re-supply stations are dwarfed by a few heavy warships. Luckily, no one seems to be paying attention to small cruisers. No ships are scanning or messaging you.</text>
+	<text>You arrive near a small Rebel refueling depot. Your ship is being scanned multiple times so they must recognize you, but there appears to be no combat-ready ships in the vicinity. The only message you receive is a denial to your request to dock at the depot.</text> 
+	<text>There is not much of interest nearby. A small sun in the distance with a few orbiting planets in nearby space provide little of interest.</text>
+	<text planet="NONE">There are no other ships near this beacon, however you detect a small communications relay. You tap into it without a problem; there are no encryptions. Most of the chatter revolves around troop and fleet movements, nothing particularly interesting.</text>
+	<text planet="PLANET_POPULATED_SMALL">There is a small planet nearby with scattered settlements. A small Rebel fleet is in orbit with many ships ferrying back and forth. It must be a recently 'liberated' planet.</text>
 </textList>
 
 
@@ -557,11 +557,11 @@
 	</choice>
 </event>
 <textList name="START_BEACON_REBEL">
-	<text>This sector was bustling with activity just a few years ago.  Now, more than half of the jump beacons have been destroyed, many settlements have been abandoned and the Rebels patrol constantly.</text>
-	<text>This sector was hit hard by the Rebellion.   The many alien settlements and stations located here are now watched over by almost an equal number of Rebel bases, heavy-handedly 'keeping the peace.'</text>
-	<text>Once the Federation forces were scattered the Rebels came down hard on the locals here.  Between the 'tax collectors' and military bases, the Rebel presence in this sector is high.</text>
-	<text>At one point this was one of the most commonly traveled sectors.  Knowing that, the Rebels have stationed a number of fleets here.  Be careful.</text>
-	<text>You will have to be very cautious in this sector.  The Rebels have full control and are no doubt looking for you.</text>
+	<text>This sector was bustling with activity just a few years ago. Now, more than half of the jump beacons have been destroyed, many settlements have been abandoned and the Rebels patrol constantly.</text>
+	<text>This sector was hit hard by the Rebellion. The many alien settlements and stations located here are now watched over by almost an equal number of Rebel bases, heavy-handedly 'keeping the peace.'</text>
+	<text>Once the Federation forces were scattered the Rebels came down hard on the locals here. Between the 'tax collectors' and military bases, the Rebel presence in this sector is high.</text>
+	<text>At one point this was one of the most commonly traveled sectors. Knowing that, the Rebels have stationed a number of fleets here. Be careful.</text>
+	<text>You will have to be very cautious in this sector. The Rebels have full control and are no doubt looking for you.</text>
 </textList>
 
 
@@ -855,7 +855,7 @@
 		<text>Intervene to defend the outpost.</text>
 		<event>
 			<ship hostile="true"/>
-			<text>The Rebel responds to your threat, "I don't know who you are, but no one defies the Rebel fleet!"  They move in to engage.</text>
+			<text>The Rebel responds to your threat, "I don't know who you are, but no one defies the Rebel fleet!" They move in to engage.</text>
 		<choice hidden="true">
 			<text>Continue...</text>
 			<event/>
@@ -1362,7 +1362,7 @@
 
 <event name="NEBULA_REBEL_BOARDING" unique="true">
 	<environment type="nebula"/>
-	<text>There appears to be a number of small stations nearby.  Before you have time to scan them, warnings go off.  A Rebel teleporter activates in one of the stations.</text>
+	<text>There appears to be a number of small stations nearby. Before you have time to scan them, warnings go off. A Rebel teleporter activates in one of the stations.</text>
 	<choice req="AE_TELEPORTER_JAMMER" hidden="true">
 		<text>(Teleporter Disruptor) Activate your disruptor field.</text>
 		<event>
@@ -1498,8 +1498,8 @@
 </event>
 <textList name="BOARDERS_REBEL_SHIP" unique="false">
 	<text>You receive a message from the nearby Rebel station's commander, "You have a lot of guts passing through our space, I'll give you that." She tells her men, "Kill their crew, I want that ship intact."</text>
-	<text>Your sensors warn of an incoming Rebel ship at the same time as the well-known computer voice of your ship AI warns you of an active enemy teleporter. You get a taunting message, "Ready to die?  I sure am ready to get a promotion!"</text>
-	<text>Incoming message, "Hello, Captain," says a Rebel in an officer's garb.  "How very generous of you to turn yourself in.  Prepare to be boarded.  Come quietly and we may be lenient."</text>
+	<text>Your sensors warn of an incoming Rebel ship at the same time as the well-known computer voice of your ship AI warns you of an active enemy teleporter. You get a taunting message, "Ready to die? I sure am ready to get a promotion!"</text>
+	<text>Incoming message, "Hello, Captain," says a Rebel in an officer's garb. "How very generous of you to turn yourself in. Prepare to be boarded. Come quietly and we may be lenient."</text>
 	<text>You receive a message on a low-band channel. "You're surrounded, just like the last of your Federation friends. Just die already." The enemy has teleported onto our ship!</text>
 	<text>As you arrive, you become aware of a small Rebel outpost near the beacon. You are hardly able to bark an order before you detect a teleporter charging and a ship moving in. They must have been expecting you...</text>
 </textList>
@@ -1762,7 +1762,7 @@
 
 <eventList name="REBEL_TRANSPORT_DESTROYED">
 	<event>
-		<text>You search the ship and discover that its cargo was new military-grade weaponry!  It was somehow undamaged in the fight and can easily be mounted on the ship.</text>
+		<text>You search the ship and discover that its cargo was new military-grade weaponry! It was somehow undamaged in the fight and can easily be mounted on the ship.</text>
 		<autoReward level="MED">weapon</autoReward>
 	</event>
 	<event>
@@ -1778,7 +1778,7 @@
 		<autoReward level="MED">scrap_only</autoReward>
 	</event>
 	<event>
-		<text>Searching the remains, you find that the cargo was a military-grade drone schematics!  You bring them aboard to install it in your ship.</text>
+		<text>Searching the remains, you find that the cargo was a military-grade drone schematics! You bring them aboard to install it in your ship.</text>
 		<autoReward level="MED">drone</autoReward>
 	</event>
 	<event>
@@ -2955,24 +2955,24 @@
 	<text>It seems like your luck came to an end. You run into a fully militarized Rebel cruiser that was just passing through this system. They hail, "This is the RS 'Oooo, Doughnuts.' We have no idea who you are, but our computer says you are a high priority target. Sorry, Captain, orders are orders.".</text>
 	<text>With the heavy Rebel presence in this sector it was only a matter of time until you would run into one of their cruisers. They send a short message. "This is the RS 'Wrecking Ball'. Our logs show you as a threat level 20 Federation unit. We will open fire with our full weapon array."</text>
 	<text planet="PLANET_POPULATED_SMALL">A cruiser is refueling at a supply-orbital near the beacon. You try to lay low but they passively scan you and immediately detach from the station to attack. A Rebel officer is put on the comms, "This is the RS 'Cuddle Buddy' We have been ordered to terminate you. Adios."</text>
-	<text planet="PLANET_POPULATED_SMALL">There is a small planet nearby with scattered settlements.  A small Rebel fleet is in orbit with many ships ferrying back and forth.  It must be a more recently 'liberated' planet. One of the cruisers, identifying as RS "Shiny Buttons And Dials", breaks formation and moves in to intercept you.</text>
-	<text>You enter a system bustling with Rebel activity.  Supply freighters and re-supply stations are dwarfed by a few heavy warships. At first you believe no one noticed you, but then one of the cruisers changes course and gets into an attack position. They identify as the RS "Not In Omicron Anymore".</text>
+	<text planet="PLANET_POPULATED_SMALL">There is a small planet nearby with scattered settlements. A small Rebel fleet is in orbit with many ships ferrying back and forth. It must be a more recently 'liberated' planet. One of the cruisers, identifying as RS "Shiny Buttons And Dials", breaks formation and moves in to intercept you.</text>
+	<text>You enter a system bustling with Rebel activity. Supply freighters and re-supply stations are dwarfed by a few heavy warships. At first you believe no one noticed you, but then one of the cruisers changes course and gets into an attack position. They identify as the RS "Not In Omicron Anymore".</text>
 
 
 <text planet="PLANET_POPULATED_REAL">This planet is densely populated and orbited by several Rebel shipyards. It's hard to count all the cruisers that are manufactured here. A guard unit moves in to intercept and hails, "This is the RS 'Suck It Up.' We are surprised that you got here without anyone noticing you. Someone will get demoted for this. Anyway, we will deal with you now."</text>
 	<text>It seems like your luck came to an end. You run into a fully militarized Rebel cruiser that was just passing through this system. They hail, "This is the RS 'That's Gotta Sting.' We have no idea who you are, but our computer says you are a high priority target. Sorry, Captain, orders are orders.".</text>
 	<text>With the heavy Rebel presence in this sector it was only a matter of time until you would run into one of their cruisers. They send a short message. "This is the RS 'Rock And Roll Hootchie Coo'. Our logs show you as a threat level 20 Federation unit. We will open fire with our full weapon array." Fleeing seems to be a suitable option here... still, taking out a cruiser would surely throw the Rebel fleet into disarray.</text>
 	<text planet="PLANET_POPULATED_SMALL">A cruiser is refueling at a supply-orbital near the beacon. You try to lay low but they passively scan you and immediately detach from the station to attack. A Rebel officer is put on the comms, "This is the RS 'Slippery When Wet' We have been ordered to terminate you. Goodbye."</text>
-	<text planet="PLANET_POPULATED_SMALL">There is a small planet nearby with scattered settlements.  A small Rebel fleet is in orbit with many ships ferrying back and forth.  It must be a more recently 'liberated' planet. One of the cruiser, identifying as RS "Discount Muffler", breaks formation and moves in to intercept you.</text>
-	<text>You enter a system bustling with Rebel activity.  Supply freighters and re-supply stations are dwarfed by a few heavy warships. At first you believe no one noticed you, but then one of the cruisers changes course and gets into an attack position. They identify as the RS "Space Radish".</text>
+	<text planet="PLANET_POPULATED_SMALL">There is a small planet nearby with scattered settlements. A small Rebel fleet is in orbit with many ships ferrying back and forth. It must be a more recently 'liberated' planet. One of the cruiser, identifying as RS "Discount Muffler", breaks formation and moves in to intercept you.</text>
+	<text>You enter a system bustling with Rebel activity. Supply freighters and re-supply stations are dwarfed by a few heavy warships. At first you believe no one noticed you, but then one of the cruisers changes course and gets into an attack position. They identify as the RS "Space Radish".</text>
 
 
 	<text planet="PLANET_POPULATED_REAL">This planet is densely populated and orbited by several Rebel shipyards. It's hard to count all the cruisers that are manufactured here. A guard unit moves in to intercept and hails, "This is the RS 'Look, A Squirrel!.' We are surprised that you got here without anyone noticing you. Someone will get demoted for this. Anyway, we will deal with you now."</text>
 	<text>It seems like you luck came to an end. You run into a fully militarized Rebel cruiser that was just passing through this system. They hail, "This is the RS 'Up Your Kilt.' We have no idea who you are, but our computer says you are a high priority target. Sorry, Captain, orders are orders.".</text>
 	<text>With the heavy Rebel presence in this sector it was only a matter of time until you would run into one of their cruisers. They send a short message. "This is the RS 'Date Your Sister?' Our logs show you as a threat level 20 Federation unit. We will open fire with our full weapons array.".</text>
 	<text planet="PLANET_POPULATED_SMALL">A cruiser is refueling on a supply-orbital near the beacon. You try to lay low but they passively scan you and immediately detach from the station to attack. A Rebel officer is put on the comms, "This is the RS 'Nocturnal Emission' We have been ordered to terminate you. Aloha."</text>
-	<text planet="PLANET_POPULATED_SMALL">There is a small planet nearby with scattered settlements.  A small Rebel fleet is in orbit with many ships ferrying back and forth.  It must be a more recently 'liberated' planet. One of the cruiser, identifying as RS "Hula Girl On Your Dashboard", breaks formation and moves in to intercept you.</text>
-	<text>You enter a system bustling with Rebel activity.  Supply freighters and re-supply stations are dwarfed by a few heavy warships. At first you believe no one noticed you, but then one of the cruisers changes course and gets into an attack position. They identify as the RS "What Was Our Name Again?".</text>
+	<text planet="PLANET_POPULATED_SMALL">There is a small planet nearby with scattered settlements. A small Rebel fleet is in orbit with many ships ferrying back and forth. It must be a more recently 'liberated' planet. One of the cruiser, identifying as RS "Hula Girl On Your Dashboard", breaks formation and moves in to intercept you.</text>
+	<text>You enter a system bustling with Rebel activity. Supply freighters and re-supply stations are dwarfed by a few heavy warships. At first you believe no one noticed you, but then one of the cruisers changes course and gets into an attack position. They identify as the RS "What Was Our Name Again?".</text>
 </textList>
 
 <event name="C_EVENT_REBEL_GUNBOAT">
@@ -3293,9 +3293,9 @@
 	<store/>
 </event>
 <textList name="STORE_REBEL">
-	<text>You discover a re-supply station used by Rebels and civilians alike.  You transmit your fake ship identification and for once, they don't seem to recognize your ship.  You try to assume the air of a local as you prepare to dock.</text>
+	<text>You discover a re-supply station used by Rebels and civilians alike. You transmit your fake ship identification and for once, they don't seem to recognize your ship. You try to assume the air of a local as you prepare to dock.</text>
 	<text>You arrive at a small space station that is putting out wide-band broadcasts on black market channels. You doubt they would turn away any business, regardless of allegiance.</text>
-	<text>You receive generic advertisements from a nearby public shipyard.  It seems they are willing to work on any ship, not only those of Rebel hue.</text>
+	<text>You receive generic advertisements from a nearby public shipyard. It seems they are willing to work on any ship, not only those of Rebel hue.</text>
 	<text planet="PLANET_POPULATED_REAL">A trade hub orbits this Rebel controlled planet. Propaganda is constantly broadcast on multiple channels. No Rebel ships are detected in the system so you decide to search for a grey market trader.</text>
 	<text planet="PLANET_POPULATED_REAL">A trade ship sells goods in the orbit of this planet. Security is lacking, they don't even check ship identification here.</text>
 </textList>
@@ -5503,7 +5503,7 @@
 	<text>You enter a system home to another robotic shipyard. Cargo transporters deliver resources and appear tiny in comparison to the massive autonomous factory cruisers. There is no way to know if the ships are aware of your presence, but for the meantime you are completely ignored. Better move on soon.</text>
 	<text>You arrive near a major refueling hub. Large solar panels power the installation and several auto ships are docked to refuel. Your ship is being scanned multiple times, but the auto forces do not react to your presence.</text> 
 	<text>There is not much of interest nearby. A small sun in the distance with a few orbiting planets in nearby space provide little of interest.</text>
-	<text planet="NONE">There are no other ships near this beacon, however you detect a small communications relay.  You try to tap into it; but the auto-chatter is heavily encrypted.</text>
+	<text planet="NONE">There are no other ships near this beacon, however you detect a small communications relay. You try to tap into it; but the auto-chatter is heavily encrypted.</text>
 	<text planet="PLANET_POPULATED_SMALL">There is a small planet nearby with a few scattered settlements. Several automated cruisers are in orbit, deactivated and de-powered. Are they guarding the settlers? You refrain from attempting communication.</text>
 	<text planet="PLANET_UNPOPULATED">Countless ship-sized tunnels and mining shafts have been beam-drilled into the crust of this planet. All resources have long since been extracted, the automated miners have moved on.</text>
 	<text>A refugee caravan guarded by Auto-Fabricators is preparing for the long journey to another sector. The humanoids explain that the Rebels are resettling them. They surely must be aware that you are not supposed to be here, but no alarm is raised. You are unsure what to make of this.</text>
@@ -6126,7 +6126,7 @@
 		<autoReward level="MED">scrap_only</autoReward>
 	</event>
 	<event>
-		<text>Searching the remains, you find that the cargo was a military-grade drone schematics!  You bring them aboard to install it in your ship.</text>
+		<text>Searching the remains, you find that the cargo was a military-grade drone schematics! You bring them aboard to install it in your ship.</text>
 		<autoReward level="MED">drone</autoReward>
 	</event>
 	<event>
@@ -6551,7 +6551,7 @@
 <textList name="CE_REBEL_AUTO_CRUISER_CONSTRUCTION_PLANET_TEXT">
 	<text planet="PLANET_POPULATED_SMALL">There is a moon nearby housing a small colony. A dormant Rebel auto cruiser remains stationary in orbit. The ship must be here to either protect, or intimidate the settlers.</text>
 	<text planet="PLANET_POPULATED_SMALL">You arrive near a planetoid covered with industrial facilities. A few settlers still live among the factories. A huge automated cruiser ascends from the surface and takes defensive position in the outer orbit. The ship is not attacking yet.</text>
-	<text>A tiny moon nearby has been turned into a quarry of galactic proportions. Entire mountain-ranges have been excavated. A small  colony on the surface houses the only life forms in the entire system, but an automated cruiser is already mining the planet crust near the humble housing pods. If the machine continues its work apace, the settlers will soon be homeless.</text>
+	<text>A tiny moon nearby has been turned into a quarry of galactic proportions. Entire mountain-ranges have been excavated. A small colony on the surface houses the only life forms in the entire system, but an automated cruiser is already mining the planet crust near the humble housing pods. If the machine continues its work apace, the settlers will soon be homeless.</text>
 </textList>
 
 

--- a/events_rock.xml.append
+++ b/events_rock.xml.append
@@ -1011,7 +1011,7 @@
 		<text>Continue...</text>
 		<event>
 			<text>I am convinced of your strength and pledge to assist your cause. We'll immediately send an advanced cruiser to the Federation fleet and we will prepare our warships to move out.</text>
-			<unlockShip id="6">The Rock deliver a cruiser to the hangar.  The Bulwark has been unlocked!</unlockShip>
+			<unlockShip id="6">The Rock deliver a cruiser to the hangar. The Bulwark has been unlocked!</unlockShip>
 			<choice hidden="true">
 				<text>Continue...</text>
 				<event>
@@ -1300,7 +1300,7 @@
 
 
 <event name="CE_ROCK_ZOLTAN_HELP" unique="true">
-	<text>It seems a Zoltan ship came here to liberate a Rock settlement from their 'oppressive belief system', and that said Rock did not appreciate it.  The chase is headed your way and the Zoltan and their pursuers will be here at any moment!</text>
+	<text>It seems a Zoltan ship came here to liberate a Rock settlement from their 'oppressive belief system', and that said Rock did not appreciate it. The chase is headed your way and the Zoltan and their pursuers will be here at any moment!</text>
 	<choice hidden="true">
 		<text>Stay and defend the Zoltan.</text>
 		<event>
@@ -2698,7 +2698,7 @@
 			<choice hidden="true" req="WEAPONS_MISSILES"> <!--JUSTIN - TO DO - Missile weapons-->
 				<text>(Missile Weapon) Attempt a controlled detonation using a missile.</text>
 				<event>
-					<text>After drawing straws, a crew member goes out to fix a modified warhead to the mine.  You detonate the missile in a way that dislodges it and it blows up shortly after. The ship takes some damage in the blasts, but you're still sailing.</text>
+					<text>After drawing straws, a crew member goes out to fix a modified warhead to the mine. You detonate the missile in a way that dislodges it and it blows up shortly after. The ship takes some damage in the blasts, but you're still sailing.</text>
 					<damage amount="3"/>
 					<damage amount="1" system="random"/>  <!--DLC-->
 					<item_modify>

--- a/events_ships.xml.append
+++ b/events_ships.xml.append
@@ -1532,10 +1532,10 @@
 	<text>The auto ship activates its self-destruct sequence. The resulting explosion will be quite hazardous.</text>
 	<text>Your receive a hail, "This is an automated message. Be advised that Rebel tech will never be left to the enemy. FTL overload activated." The AI will detonate its core.</text>
 	<text>The scanners show high energy spikes in the auto ship's main reactor. It seems it will try to suicide in order to deal some damage to your ship.</text>
-	<text>"Core breach! Warning! This unit has initiated a core breach.  Containment fields shutting down..." Now would probably be a good time to evacuate.</text>
+	<text>"Core breach! Warning! This unit has initiated a core breach. Containment fields shutting down..." Now would probably be a good time to evacuate.</text>
 	<text>FTL field arcs begin to flicker around the enemy ship as its FTL core energy levels start to climb beyond the safety limits.</text>
 	<text>"Critical damage sustained. Initializing self destruction protocol."</text>
-	<text>"This unit's remains shall not fall into the hands of the enemy." A tremendous spike in the enemy's FTL signature warns you that its core containment has been shut off.  This is going to sting...</text>
+	<text>"This unit's remains shall not fall into the hands of the enemy." A tremendous spike in the enemy's FTL signature warns you that its core containment has been shut off. This is going to sting...</text>
 	<text>FTL levels around the enemy suddenly increase tremendously as its FTL core starts to overload.</text>
 	 <text>Energy levels suddenly spike on the enemy craft. This is not good.</text>
 </textList>
@@ -1822,7 +1822,7 @@
 		<ship hostile="true"/>
 	</escape> 
 	<gotaway>
-		<text>Your crew reports, "Enemy FTL charge complete.  Brace!"</text>
+		<text>Your crew reports, "Enemy FTL charge complete. Brace!"</text>
 		<choice req="FTL_JUMPER" hidden="true"> 
 			<text>(Advanced Navigation AI) Say a quick prayer.</text>
 			<event>
@@ -2609,7 +2609,7 @@
 <ship name="C_FED_CRUISER_RESCUE" auto_blueprint="C_SHIPS_REBEL_CRUISER">
 	<escape  min="6" max="7" load="C_CRUISER_ESCAPE"/>
 	<gotaway>
-		<text>The Rebel cruiser jumps away, leaving a massive ripple in the fabric of space-time. They  must be contacting fleet command right now, informing every ship in the sector of your whereabouts. At least you can contact their would-be victim.</text>
+		<text>The Rebel cruiser jumps away, leaving a massive ripple in the fabric of space-time. They must be contacting fleet command right now, informing every ship in the sector of your whereabouts. At least you can contact their would-be victim.</text>
 		<modifyPursuit amount="1"/>
 		<choice hidden="true"> 
 			<text>Contact the survivors.</text>

--- a/events_slug.xml.append
+++ b/events_slug.xml.append
@@ -1376,7 +1376,7 @@
 		</choice>
 	</event>
 	<event>
-		<text>Just before the transmission is cut you hear, "They're not falling for it.  Just kill the crew and we can ssstrip..." Looks like you're not getting out of here without a fight.</text>
+		<text>Just before the transmission is cut you hear, "They're not falling for it. Just kill the crew and we can ssstrip..." Looks like you're not getting out of here without a fight.</text>
 		<ship load="JELLY" hostile="true"/>
 		<choice hidden="true">
 			<text>Continue...</text>
@@ -1433,7 +1433,7 @@
 	<choice hidden="true">
 		<text>Decline.</text>
 		<event>
-			<text>"Oh well... We ssshall wait here then."  You cautiously put distance between your ships before preparing to jump.</text>
+			<text>"Oh well... We ssshall wait here then." You cautiously put distance between your ships before preparing to jump.</text>
 		</event>
 	</choice>
 	<choice hidden="true">
@@ -1526,7 +1526,7 @@
 </event>
 <eventList name="NEBULA_SLUG_FAKE_STORE_LIST">  <!-- if you stay for the whole thing -->
 	<event>
-		<text>"Great. Let me show you our waress.  It's not often I meet patient alienss, have this complimentary fuel as well."</text>
+		<text>"Great. Let me show you our waress. It's not often I meet patient alienss, have this complimentary fuel as well."</text>
 		<item_modify>
 			<item type="fuel" min="5" max="5"/>
 		</item_modify>
@@ -3307,7 +3307,7 @@
 	<choice hidden="true">
 		<text>Weapons.</text>
 		<event>
-			<text>"Your acceptance of death is almosst admirable... Almosst." Your weapons system registers a hacking module.  You hardly have time to respond before they attack.</text>
+			<text>"Your acceptance of death is almosst admirable... Almosst." Your weapons system registers a hacking module. You hardly have time to respond before they attack.</text>
 			<status type="divide" target="player" system="weapons" amount="2"/>
 			<ship load="JELLY_STATUS_WEAPONS" hostile="true"/>
 		<choice hidden="true">

--- a/events_zoltan.xml.append
+++ b/events_zoltan.xml.append
@@ -7454,11 +7454,11 @@
 </textList>
 <eventList name="AI_VS_FEDERATION_SAVED_LIST">
 	<event>
-		<text>"Thanks, we eh... are on an important courier mission and hoped it would be safe to pass through this sector.  Take some extra supplies as thanks for your aid."</text>
+		<text>"Thanks, we eh... are on an important courier mission and hoped it would be safe to pass through this sector. Take some extra supplies as thanks for your aid."</text>
 		<autoReward level="MED">standard</autoReward>
 	</event>
 	<event>
-		<text>"Thanks, we eh... are on an important courier mission and hoped it would be safe to pass through this sector.  Let us patch up some of your hull as thanks for your aid."</text>
+		<text>"Thanks, we eh... are on an important courier mission and hoped it would be safe to pass through this sector. Let us patch up some of your hull as thanks for your aid."</text>
 		<damage amount="-3"/>
 	</event>
 </eventList>

--- a/misc.xml.rawappend
+++ b/misc.xml.rawappend
@@ -748,7 +748,7 @@
 
 <text name="tip_hull">Tip: Hull weapons deal double damage if they hit a room that does not have a system or a subsystem.</text>
 
-<text name="tip_charge">Tip: Charge weapons can be charged multiple times to generate more firepower.  You can save time and fire the weapon prematurely but it will have fewer shots ready as a result.</text>
+<text name="tip_charge">Tip: Charge weapons can be charged multiple times to generate more firepower. You can save time and fire the weapon prematurely but it will have fewer shots ready as a result.</text>
 
 <text name="tip_chain_laser">Tip: Chain lasers decrease their cooldown every time they fire. Check the green lights on the weapon to see how many times it has fired.</text>
 

--- a/newEvents.xml.append
+++ b/newEvents.xml.append
@@ -204,40 +204,40 @@
 	<text>TIP: Grinding Sectors -  It can be beneficial to stay in a Sector for as long as possible to improve the ship since each Sector is increasingly difficult.</text>
 	<text>TIP: Exits -  It's tempting to rush for the sector exits, but exploring is the only way to upgrade your ship. Try and get as much out of each sector as possible.</text>
 	<text>TIP: Pausing -  Press SPACE at any time to pause the game. You can still issue orders to crew or manipulate system power while paused.</text>
-	<text>TIP: Targets -  Prioritize your targeting in combat.  Weapons and Shields are usually the best choice, but if they're fleeing, hit their Engines or Piloting to prevent escape.</text>
+	<text>TIP: Targets -  Prioritize your targeting in combat. Weapons and Shields are usually the best choice, but if they're fleeing, hit their Engines or Piloting to prevent escape.</text>
 	<text>TIP: Hidden Choices -  When you see a blue colored choice in an event, it's a special option that has been made available by your current equipment.</text>
 	<text>TIP: System Damage -  When a System fully breaks due to fire or boarders, the hull also takes one damage.</text>
-	<text>TIP: Selling -  Weapons, drones, and augments can be sold for 1/2 the purchasing price at stores.  Click on the SELL tab at the top.</text>
+	<text>TIP: Selling -  Weapons, drones, and augments can be sold for 1/2 the purchasing price at stores. Click on the SELL tab at the top.</text>
 	<text>TIP: Power Bars - Upgraded systems can be helpful even if you don't have enough reactor power to use them; they still absorb one damage.</text>
 	<text>TIP: Weapons -  You can queue up an attack before the weapon is charged. It will fire when it's charged.</text>
 	<text>TIP: Cloaking -  Cloaking prevents enemies from firing on your ship or charging their weapons. It also causes all currently flying shots to miss your ship.</text>
 	<text>TIP: Boarding -  If you're having trouble with boarders, fight within the medbay. If all else fails, vent the rest of the oxygen out of the ship!</text>
 	<text>TIP: Oxygen -  If the ship's room color changes from tan to red, it means you're losing oxygen. Crew will be damaged and fires will burn out in rooms with an orange border.</text>
-	<text>TIP: Shield Piercing -  Missiles ignore shields.  Use missiles to damage a powerful ship's Shield System. Just remember that Defense Drones can shoot down missiles!</text>
+	<text>TIP: Shield Piercing -  Missiles ignore shields. Use missiles to damage a powerful ship's Shield System. Just remember that Defense Drones can shoot down missiles!</text>
 	<text>TIP: Choices -  Results of most choices have multiple outcomes. You can never be sure what will happen.</text>
 	<text>TIP: Autofire -  Autofire will let a weapon maintain its target. Just keep an eye on your missile count!</text>
 	<text>TIP: Evasion -  Evading enemy shots is crucial but it requires functioning engines AND a pilot. Having someone man the engines will increase your evasion as well.</text>
 	<text>TIP: Sensors -  If the ship goes dark, don't panic. Just fix the Sensors Subsystem.</text>
 	<text>TIP: Drones -  If you're struggling against enemy Drones, target the Drone System to temporarily disable them.</text>
-	<text>TIP: Beams -  Beam weapons do damage based on the number of rooms they hit.   Each Shield bubble will block 1 damage of a beam; it's best to use beams when their shields are down.</text>
-	<text>TIP: Fire -  If fire is spreading, consider opening airlocks and doors to vent the oxygen from parts of your ship.  Fire is quickly extinguished without O2.</text>
-	<text>TIP: Health -  Pay attention to your crew's health!  Use the medbay to keep them patched up.</text>
-	<text>TIP: Upgrades -  Don't forget to upgrade your ship!  Often shields are the highest priority, but don't underestimate the usefulness of subsystems.</text>
-	<text>TIP: Fuel -  Every jump consumes one unit of fuel, so keep an eye on your reserves.  Buy fuel at stores to avoid being left stranded.</text>
+	<text>TIP: Beams -  Beam weapons do damage based on the number of rooms they hit.  Each Shield bubble will block 1 damage of a beam; it's best to use beams when their shields are down.</text>
+	<text>TIP: Fire -  If fire is spreading, consider opening airlocks and doors to vent the oxygen from parts of your ship. Fire is quickly extinguished without O2.</text>
+	<text>TIP: Health -  Pay attention to your crew's health! Use the medbay to keep them patched up.</text>
+	<text>TIP: Upgrades -  Don't forget to upgrade your ship! Often shields are the highest priority, but don't underestimate the usefulness of subsystems.</text>
+	<text>TIP: Fuel -  Every jump consumes one unit of fuel, so keep an eye on your reserves. Buy fuel at stores to avoid being left stranded.</text>
 	<text>TIP: Sound -  Go into the options menu to turn on or off the sound effects and music.</text>
 	<text>TIP: Asteroids -  Fighting in asteroid fields is dangerous, but use it to your advantage. Take out enemy shields and let the rocks take care of the rest.</text>
 	<text>TIP: Nebulae -  Passing through a Nebula will allow you to temporarily slow down the fleet advancement but they contain their own unique dangers.</text>
 	<text>TIP: Solar Flares - Solar flares will cause hull damage in addition to starting fires. Make sure your shields are up to help mitigate this effect.</text>
 	<text>TIP: Score - Your score is based on how many ships you defeat, the number of beacons explored, and your total scrap collection.</text>
 	<text>TIP: Hotkeys -  You can charge or arm weapons using number hotkeys:  The Weapon Slots are 1-4 on your keyboard, and the Drones are 5-7 (customizable in the options).</text>
-	<text>TIP: Augmentations -  Your ship can only hold 3 augmentations.  They provide unique benefits to a system, the crew or the entire ship.</text>
+	<text>TIP: Augmentations -  Your ship can only hold 3 augmentations. They provide unique benefits to a system, the crew or the entire ship.</text>
 	<text>TIP: Breaches -  If a room with a breach has no Oxygen, try opening all the doors surrounding it to make it less hazardous.</text>
 	<text>TIP: Font Size - Pressing +/- (customizable in options) will let you change the event text size.</text>
 	<text>TIP: Rebel fleet - The rebel fleet (represented by the red circle on the map) moves closer to your position every time you jump. Certain events can slow or speed up their movement speed.</text>
 	<text>TIP: Weapon Order - Rearrange a weapon or drone schematic by dragging it into the desired position. The left-most slot will be the last to power down if the system is damaged.</text>
-	<text>TIP: Ion Weapons - Ion weapons de-power and lock a System for a time.  If they hit the enemy shields they deal their stun damage directly to the Shields System.</text>
-	<text>TIP: Bomb Weapons - Bombs teleport directly onto either ship.  They bypass Shields AND Defense Drones.  However they affect crew and Systems; they do no damage to the ships hull.</text>
-	<text>TIP: Door Subsystem - Upgrading your doors once will greatly reduce the chance fire will spread between rooms.  Upgrading them again will cause doors to significantly slow boarder movement.</text>
+	<text>TIP: Ion Weapons - Ion weapons de-power and lock a System for a time. If they hit the enemy shields they deal their stun damage directly to the Shields System.</text>
+	<text>TIP: Bomb Weapons - Bombs teleport directly onto either ship. They bypass Shields AND Defense Drones. However they affect crew and Systems; they do no damage to the ships hull.</text>
+	<text>TIP: Door Subsystem - Upgrading your doors once will greatly reduce the chance fire will spread between rooms. Upgrading them again will cause doors to significantly slow boarder movement.</text>
 	<text>TIP: Armed Space Stations - Enemy space stations have strong hulls but usually no engines. That means they can not move and therefore are unable to dodge. Use this to your advantage.</text>
 	<text>TIP: Light Lasers - These lasers are good for killing crew, but can not deplete shields or damage systems and ship hull. Use them to empty ships of personnel or to support your boarders and keep an eye on your crews health when you are taking fire from light lasers.</text>
 	<text>TIP: Auto Lasers - These lasers seem weak on their own, but can make formidable support weapons if you can deplete the enemy shields with other guns.</text>

--- a/newEvents.xml.append
+++ b/newEvents.xml.append
@@ -314,12 +314,12 @@
 	<text>TIP: Enemy Combat Augments - Enemy combat augments work just like the ones deployed by you. Discovering the effects and limitations of different combat augments can teach you how to defend yourself against them.</text>
 	<text>TIP: Ice Fields - Ice fields exist in remote areas far away from active stars. These areas have almost no background radiation to speak of, which makes cloaking devices useless and hiding impossible within them.</text>
 	<text>TIP: Zoltan Diplomacy - Commanding a ship of the wise Zoltan will give you a natural degree of authority. You will be able to negotiate favorable surrender offers and find peaceful resolutions for many conflicts.</text>
-	<text>TIP: Slug "Flexibility" - The Federation is well know to use Slug auxiliaries for their dirty work. Your crew will not expect you to stick to the rules if you command a Slug vessel.</text>
+	<text>TIP: Slug "Flexibility" - The Federation is well known to use Slug auxiliaries for their dirty work. Your crew will not expect you to stick to the rules if you command a Slug vessel.</text>
 	<text>TIP: Player Surrender - Remember that you often can try to surrender if you are actively attacked. This might cost you some resources, but can save you life in certain situations.</text>
 	<text>TIP: Breaking Ceasefire Agreements - Attacking an opponent whose surrender offer has been accepted constitutes a galactic war crime. This might disturb your crew a bit.</text>
 	<text>TIP: Making Surrender Offers - Bigger compensation offers will increase the chance of your surrender being accepted. Most opponents will always accept a great offer.</text>
 	<text>TIP: Trustworthiness of Opponents - Not all your opponents will obey to the general etiquette of space combat. Certain factions might attack you again after you transfered a surrender offer.</text>
-	<text>TIP: Outposts - This military stations are well armed. Prepare for a tough fight when happening upon one.</text>
+	<text>TIP: Outposts - These military stations are well armed. Prepare for a tough fight when happening upon one.</text>
 	<text>TIP: Checkpoints - Checkpoint stations are often attacked and are therefore equipped with clone bays to protect their staff. They can have various other systems as well.</text>
 	<text>TIP: EW Platforms - Electronic Warfare stations are always equipped with hacking systems. Be prepared to deal with system disruption when engaging them.</text>
 	<text>TIP: Hives and Broodstations - Some factions heavily rely on cloning facilities to swell their ranks. When you find yourself near one of their cloning stations you will have to deal with almost endless waves of boarders.</text>
@@ -328,7 +328,7 @@
 	<text>TIP: Artillery System - The expensive artillery system you can buy at stores will equip your ship with its signature artillery weapon, often providing a strong boost for your offense.</text>
 	<text>TIP: Faction Artillery - Buy the artillery system to discover the various artillery guns available. Certain ships might receive different kinds of artillery.</text>
 	<text>TIP: Artillery Offense - Some ships have access to devastating artillery, but depend on normal weapons to weaken enemy defenses.</text>
-	<text>TIP: Non-Lethal Artillery - Some artillery weapons deal no damage, but never the less provide great advantages in combat. For example by ionizing enemy ships or incapacitating crew.</text>
+	<text>TIP: Non-Lethal Artillery - Some artillery weapons deal no damage, but nevertheless provide great advantages in combat, such as ionizing enemy ships or incapacitating crew.</text>
 	<text>TIP: Combat Events - A lot of things can happen in ship-to-ship combat. Don't let your guard down.</text>
 	<text>TIP: Combat Augment Power Cost - The energy cost of combat augments can be offset with the internal generator augment. You can engineer it at empty beacons if you have combat augments.</text>
 	<text>TIP: Auto Sectors - This sectors are under the control of automated construction ships. You will rarely encounter manned ships here.</text>

--- a/newEvents.xml.append
+++ b/newEvents.xml.append
@@ -276,7 +276,7 @@
 	<text>TIP: Light Drones - These drones are designed to injure enemy crew, but cannot damage the enemy ship's hull. They are especially useful to soften up resistance before your boarders move in.</text>
 	<text>TIP: Ion Drones - These drones are mainly useful for ionizing enemy shields as you can not control where they aim.</text>
 	<text>TIP: Ship Size - The amount of rooms an enemy ship has factors into how effective certain drones are against them. Most drones excel when attacking smaller ships, because they are more likely to hit crew and systems.</text>
-	<text>TIP: Cargo Ships and Freighters - These ship often carry valuable cargo. They posses little firepower and rely on powerful engines and jump drives to ovoid confrontations.</text>
+	<text>TIP: Cargo Ships and Freighters - These ships often carry valuable cargo. They possess little firepower and rely on powerful engines and jump drives to avoid confrontations.</text>
 	<text>TIP: Hazard Sectors - The Rebel fleet will struggle to pursue you through these sectors full of ion storms and asteroid fields. Exploring them isn't always advisable. Hazard Sectors have little infrastructure and are full of dangers.</text>
 	<text>TIP: Civilian Coreworlds - These peaceful sectors offer a lot of opportunities to work and trade, but be careful, losing the Rebel fleet will be harder in populated areas and you never know who might give your position away to them.</text>
 	<text>TIP: Federation Controlled Sectors - Federation controlled sectors will be under Rebel attack when you arrive. There will be fierce fighting almost everywhere.</text>


### PR DESCRIPTION
Deleted extra spaces in between sentences and words (double spaces replaced with a single space) in all of the events files. Got distracted in between but I wanted to make sure I did one pull request for all the files.

Fixed some of the game start tips in newEvents to read better and fixed some typos

Fixed a typo, changed a word to the correct form, and deleted some duplicate "the" 's in events.xml.append.

A minor change to the readme.

Deleted an extra space in the Pegasus weapon blueprint tooltip, in case someone wants to make it artillery, who knows? Looks nicer regardless.