### PR TITLE
changed "you ship" to "your ship" in nearly every case, missing letter, and "coms" to "comms"

### DIFF
--- a/events.xml.append
+++ b/events.xml.append
@@ -7962,7 +7962,7 @@
 		<damage amount="2" system="random" effect="fire"/>
 	</event>
 	<event>
-		<text>You extract the recovery arms and grab the ammo in fly by. If you ship is equipped with compatible launchers, you could even fire it at your enemy now.</text>
+		<text>You extract the recovery arms and grab the ammo in fly by. If your ship is equipped with compatible launchers, you could even fire it at your enemy now.</text>
 		<item_modify>
 			<item type="missiles" min="3" max="4"/>
 		</item_modify>	
@@ -21611,7 +21611,7 @@
 			</event>
 		</choice>
 		<choice req="ENERGY_SHIELD" hidden="true">
-			<text>(Zoltan Ship) Upgrade you ship with specialized shield phase technology for teleporters. [ Scrap: -70; Augment: Zoltan Shield Bypass ]</text>
+			<text>(Zoltan Ship) Upgrade your ship with specialized shield phase technology for teleporters. [ Scrap: -70; Augment: Zoltan Shield Bypass ]</text>
 			<event>
 				<text>The ship computer contains all available data on the advanced Zoltan shields. This allows you to upgrade teleporter devices so that they can bypass them.</text>
 				<item_modify>
@@ -22301,7 +22301,7 @@
 			</event>
 		</choice>
 		<choice req="ENERGY_SHIELD" hidden="true">
-			<text>(Zoltan Ship) Upgrade you ship with specialized shield phase technology for teleporters. [ Scrap: -70; Augment: Zoltan Shield Bypass ]</text>
+			<text>(Zoltan Ship) Upgrade your ship with specialized shield phase technology for teleporters. [ Scrap: -70; Augment: Zoltan Shield Bypass ]</text>
 			<event>
 				<text>The ship computer contains all available data on the advanced Zoltan shields. This allows you to upgrade teleporter devices so that they can bypass them.</text>
 				<item_modify>

--- a/events.xml.append
+++ b/events.xml.append
@@ -14283,7 +14283,7 @@
 	<text>You point out that both sides have proven their worth in combat and offer an exchange of goods. You has little choice but to agree.</text>
 	<text>You agree that this was all a misunderstanding and ask if you can further help you former opponent. They decline and willingly transmit supplies, knowing that violating the rules might get them in trouble with the Zoltan later.</text>
 	<text>You immediately power down the weapons to show your good will. A deal favorable for both factions is struck in order to compensate for the damage that was done.</text>
-	<text>Seems coms are sometimes still mightier than weapons. You reach a favorable agreement.</text>
+	<text>Seems comms are sometimes still mightier than weapons. You reach a favorable agreement.</text>
 	<text>Your opponent has to compensate you for the damage done. So says the law.</text>
 	<text>Exchange of weapon fire is followed by an exchange of goods. You are glad that this did not have to end in further bloodshed.</text>
 	<text>For once, diplomacy prevails. Maybe peace still has a chance in this galaxy?</text>
@@ -28638,7 +28638,7 @@
 		<damage amount="3" system="random" effect="breach"/>
 	</event>
 	<event>	
-		<text>Just after you give the salvage order, several Rebel cruisers fire their ASB and a full volley crushes into your ship. The salvage team screams through the coms: "We can't stay here captain, you'll get us all killed!"</text>
+		<text>Just after you give the salvage order, several Rebel cruisers fire their ASB and a full volley crushes into your ship. The salvage team screams through the comms: "We can't stay here captain, you'll get us all killed!"</text>
 		<environment type="PDS" target="player"/>
 		<damage amount="3" system="room" effect="breach"/>
 		<damage amount="3" system="random" effect="breach"/>

--- a/events_boss.xml.append
+++ b/events_boss.xml.append
@@ -1127,7 +1127,7 @@
 				<choice hidden="true">
 					<text>"Eeh, well..."</text>
 					<event>
-						<text>"Seriously? Who are you anyway? This is a wast of time. Why don't you show us what your ship really is capable of. Come at us!" The massive flagship swings around and approaches you dead on. Battle station!</text>
+						<text>"Seriously? Who are you anyway? This is a waste of time. Why don't you show us what your ship really is capable of. Come at us!" The massive flagship swings around and approaches you dead on. Battle station!</text>
 		<choice req="AE_ADV_EFFECTOR" hidden="true"> 
 			<text>(Internal Effector) "Prepare for offensive cyber-attack. Hack this thing!"</text> 
 			<event load="CE_PRE_FIGHT_EFFECTOR"/>

--- a/events_boss.xml.append
+++ b/events_boss.xml.append
@@ -1127,7 +1127,7 @@
 				<choice hidden="true">
 					<text>"Eeh, well..."</text>
 					<event>
-						<text>"Seriously? Who are you anyway? This is a wast of time. Why don't you show us what you ship really is capable of. Come at us!" The massive flagship swings around and approaches you dead on. Battle station!</text>
+						<text>"Seriously? Who are you anyway? This is a wast of time. Why don't you show us what your ship really is capable of. Come at us!" The massive flagship swings around and approaches you dead on. Battle station!</text>
 		<choice req="AE_ADV_EFFECTOR" hidden="true"> 
 			<text>(Internal Effector) "Prepare for offensive cyber-attack. Hack this thing!"</text> 
 			<event load="CE_PRE_FIGHT_EFFECTOR"/>

--- a/events_engi.xml.append
+++ b/events_engi.xml.append
@@ -5013,7 +5013,7 @@
 	<text>A military vessel moves in to intercept after spotting you at this beacon. The quarantine fleet must be aware that you intend to leave this sector soon. You might spread the disease to other sectors.</text>
 	<text>A vessel of the quarantine fleet hails on broadband channels, "Federation vessel, you might spread the disease to other regions by leaving this sector. Your ship is under lockdown." You can't let them stop you.</text>
 	<text>A military ship is guarding this jump node. They request your identification, but radiation from the sun in this system is disrupting your communications. They take your silence for aggression and move in to attack.</text>
-	<text>You receive a message, "This area is off limits. You ship has violated quarantine procedures. Turn yourself in." It's only a single guard ship. The crew gets ready to fight.</text>
+	<text>You receive a message, "This area is off limits. Your ship has violated quarantine procedures. Turn yourself in." It's only a single guard ship. The crew gets ready to fight.</text>
 </textList>
 
 <event name="QUARANTINE_PATROL_AUGMENTED" unique="true">

--- a/events_fuel.xml.append
+++ b/events_fuel.xml.append
@@ -1016,7 +1016,7 @@
 			</event>
 		</choice>
 		<choice req="ENERGY_SHIELD" hidden="true">
-			<text>(Zoltan Ship) Upgrade you ship with specialized shield phase technology for teleporters. [ Scrap: -70; Augment: Zoltan Shield Bypass ]</text>
+			<text>(Zoltan Ship) Upgrade your ship with specialized shield phase technology for teleporters. [ Scrap: -70; Augment: Zoltan Shield Bypass ]</text>
 			<event>
 				<text>The ship computer contains all available data on the advanced Zoltan shields. This allows you to upgrade teleporter devices so that they can bypass them.</text>
 				<item_modify>

--- a/events_pirate.xml.append
+++ b/events_pirate.xml.append
@@ -2020,7 +2020,7 @@
 	<text>You barely have time to register jump completion before your ship warns you of an incoming ship with weapons hot.</text>
 	<text>A small blip appears on the system map. The sector archive lists this ship as a local pirate with a long rap sheet. "Unidentified cruiser, surrender or you will be destroyed." They are closing in fast.</text>
 	<text>A small ship remains stationary in the distance. Its captain hails and claims that she is a Federation requisition officer, here to collect the war toll from passing ships. When you demand to see the official requisition license, the ship's weapons come live. "You resist a Federation official? We will take what we demand by force then."</text>
-	<text>The captain of this ship with pirate markings claims to be an official Rebel requisition officer. When you refuse to donate to the Rebellion, the ship cuts coms and moves in to attack.</text>
+	<text>The captain of this ship with pirate markings claims to be an official Rebel requisition officer. When you refuse to donate to the Rebellion, the ship cuts comms and moves in to attack.</text>
 </textList>
 
 

--- a/events_rebel.xml.append
+++ b/events_rebel.xml.append
@@ -6350,7 +6350,7 @@
 		<choice>
 			<text>Continue...</text>
 			<event>
-				<text>A synthetic screeching tears through the coms when you open a channel. A split-second later, searchlights blind your eyes. The shape of an automated cruiser becomes visible. It accelerates in your direction, greedily extending its mechanical arms towards you. There is no way but back, even though the shaft barely gives you enough room to turn and you'll only be able to navigate with basic thrusters.</text>
+				<text>A synthetic screeching tears through the comms when you open a channel. A split-second later, searchlights blind your eyes. The shape of an automated cruiser becomes visible. It accelerates in your direction, greedily extending its mechanical arms towards you. There is no way but back, even though the shaft barely gives you enough room to turn and you'll only be able to navigate with basic thrusters.</text>
 				<ship load="C_AUTO_CRUISER_CONSTRUCTION_FACTORY" hostile="true"/>
 				<status type="limit" target="enemy" system="engines" amount="1"/>
 		<choice hidden="true">
@@ -6426,7 +6426,7 @@
 		<choice>
 			<text>Continue...</text>
 			<event>
-				<text>A synthetic screeching tears through the coms when you open a channel and the next moment searchlights blind your eyes. The shape of an automated cruiser becomes visible. It accelerates in your direction, greedily extending its mechanical arms towards you. There is no way but back, even though the shaft barely gives you enough room to turn.</text>
+				<text>A synthetic screeching tears through the comms when you open a channel and the next moment searchlights blind your eyes. The shape of an automated cruiser becomes visible. It accelerates in your direction, greedily extending its mechanical arms towards you. There is no way but back, even though the shaft barely gives you enough room to turn.</text>
 				<ship load="C_AUTO_CRUISER_CONSTRUCTION_FACTORY" hostile="true"/>
 				<status type="limit" target="enemy" system="engines" amount="1"/>
 		<choice hidden="true">

--- a/events_ships.xml.append
+++ b/events_ships.xml.append
@@ -4080,7 +4080,7 @@
 
 <ship name="PIRATE_ACID" auto_blueprint="SHIPS_PIRATE">
 	<surrender chance="0.5" min="1" max="5">
-		<text>The hull of your opponent immediately corrodes wherever it is hit, leaving trails of ugly yellow fog behind. You ship probably does not look much better.</text>
+		<text>The hull of your opponent immediately corrodes wherever it is hit, leaving trails of ugly yellow fog behind. Your ship probably does not look much better.</text>
 		<choice hidden="true">
 			<text>Continue...</text>
 			<event load="CE_ACID_FIGHT_LIST"/>


### PR DESCRIPTION
-- except for the case where it is used in the adjective form, "you ship rat".
-- closed the previous nearly identical pull request because there was another typo right there in a spellechecked text in events_boss which I would probably forget if I waited.